### PR TITLE
Create hugo.yml

### DIFF
--- a/.github/workflows/hugo.yml
+++ b/.github/workflows/hugo.yml
@@ -1,0 +1,75 @@
+# Sample workflow for building and deploying a Hugo site to GitHub Pages
+name: Deploy Hugo site to Pages
+
+on:
+  # Runs on pushes targeting the default branch
+  push:
+    branches: ["master"]
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Allow only one concurrent deployment, skipping runs queued between the run in-progress and latest queued.
+# However, do NOT cancel in-progress runs as we want to allow these production deployments to complete.
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
+# Default to bash
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  # Build job
+  build:
+    runs-on: ubuntu-latest
+    env:
+      HUGO_VERSION: 0.114.0
+    steps:
+      - name: Install Hugo CLI
+        run: |
+          wget -O ${{ runner.temp }}/hugo.deb https://github.com/gohugoio/hugo/releases/download/v${HUGO_VERSION}/hugo_extended_${HUGO_VERSION}_linux-amd64.deb \
+          && sudo dpkg -i ${{ runner.temp }}/hugo.deb
+      - name: Install Dart Sass
+        run: sudo snap install dart-sass
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          submodules: recursive
+      - name: Setup Pages
+        id: pages
+        uses: actions/configure-pages@v3
+      - name: Install Node.js dependencies
+        run: "[[ -f package-lock.json || -f npm-shrinkwrap.json ]] && npm ci || true"
+      - name: Build with Hugo
+        env:
+          # For maximum backward compatibility with Hugo modules
+          HUGO_ENVIRONMENT: production
+          HUGO_ENV: production
+        run: |
+          hugo \
+            --minify \
+            --baseURL "${{ steps.pages.outputs.base_url }}/"
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v2
+        with:
+          path: ./public
+
+  # Deployment job
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v2


### PR DESCRIPTION
- nazwa: Zamknij nieaktualne problemy używa: action/stale@v4.1.1 z: # Token dla repozytorium. Można przekazać za pomocą `{{ secrets.GITHUB_TOKEN }}`. repo-token: # opcjonalny, domyślny to ${{ github.token }} # Wiadomość, którą należy opublikować w sprawie problemu podczas tagowania. Jeśli nie podano żadnego, nie oznacza to, że problemy są nieaktualne. komunikat-zestarzałego problemu: # opcjonalny # Wiadomość do opublikowania w żądaniu ściągnięcia podczas tagowania. Jeśli nie podano żadnego, żądania ściągnięcia nie zostaną oznaczone jako nieaktualne. nieaktualne-pr-message: # opcjonalne # Wiadomość, którą należy opublikować w sprawie problemu podczas jej zamykania. Jeśli nie podano żadnego, nie będę komentował przy zamykaniu problemu. komunikat o zamknięciu problemu: # opcjonalny # Wiadomość do opublikowania w żądaniu ściągnięcia podczas jego zamykania. Jeśli nie zostanie podany, nie będzie komentowany podczas zamykania żądań ściągnięcia. wiadomość-pr: # opcjonalna # Liczba dni, od których może upłynąć problem lub żądanie ściągnięcia, zanim zostanie oznaczony jako nieaktualny. Ustaw na -1, aby nigdy automatycznie nie oznaczać problemów ani żądań ściągnięcia jako nieaktualnych. dni-przed-nieaktualne: # opcjonalne, wartość domyślna to 60 # Liczba dni, w których problem może istnieć, zanim zostanie oznaczony jako nieaktualny. Ustaw na -1, aby nigdy nie oznaczać automatycznie problemów jako nieaktualnych. Zastąp opcję „dni przed nieaktualnością” dotyczącą tylko problemów. dni-przed-wydaniem-nieaktualne: # opcjonalne # Liczba dni, które może mieć żądanie ściągnięcia, zanim zostanie oznaczone jako nieaktualne. Ustaw na -1, aby nigdy nie oznaczać automatycznie żądań ściągnięcia jako nieaktualnych. Zastąp opcję „dni przed nieaktualnymi” dotyczącą tylko żądań ściągnięcia. dni-przed-pr-stale: # opcjonalne # Liczba dni oczekiwania na zamknięcie problemu lub żądania ściągnięcia po oznaczeniu go jako nieaktualnego. Ustaw na -1, aby nigdy nie zamykać nieaktualnych problemów ani żądań ściągnięcia. dni przed zamknięciem: # opcjonalne, domyślnie 7 # Liczba dni oczekiwania na zamknięcie problemu po oznaczeniu go jako nieaktualny. Ustaw na -1, aby nigdy nie zamykać nieaktualnych problemów. Zastąp opcję „dni przed zamknięciem” dotyczącą tylko problemów. dni-przed-zamknięciem-wydania: # opcjonalne # Liczba dni oczekiwania na zamknięcie żądania ściągnięcia po oznaczeniu go jako nieaktualne. Ustaw na -1, aby nigdy nie zamykać nieaktualnych żądań ściągnięcia. Zastąp opcję „dni przed zamknięciem” dotyczącą tylko żądań ściągnięcia. dni-przed-pr-zamknięciem: # opcjonalne # Etykieta do zastosowania, gdy problem jest nieaktualny. nieaktualne-emisyjne-label: # opcjonalne, domyślnie jest to Nieaktualne # Etykieta do zastosowania po zamknięciu problemu. etykieta zamykającego wydania: # opcjonalne # Etykiety oznaczające problem nie są oznaczane jako nieaktualne. Poszczególne etykiety oddziel przecinkami (np. „etykieta1,etykieta2”). etykiety-wydań-wyjątków: # opcjonalne, domyślnie # Etykieta do zastosowania, gdy żądanie ściągnięcia jest nieaktualne. stare-pr-label: # opcjonalne, domyślnie jest to Nieaktualne # Etykieta do zastosowania po zamknięciu żądania ściągnięcia. zamknij-pr-label: # opcjonalne # Etykiety oznaczające żądanie ściągnięcia nie są oznaczane jako nieaktualne. Poszczególne etykiety oddziel przecinkami (np. „etykieta1,etykieta2”). zwolnienia-pr-labels: # opcjonalne, domyślnie # Kamienie milowe oznaczające problem lub żądanie ściągnięcia nie są oznaczane jako nieaktualne. Poszczególne kamienie milowe oddziel przecinkami (np. „kamień milowy 1, kamień milowy 2”). zwolnienia-kamienie milowe: # opcjonalne, domyślnie # Kamienie milowe oznaczające, że problem nie jest oznaczany jako nieaktualny. Poszczególne kamienie milowe oddziel przecinkami (np. „kamień milowy 1, kamień milowy 2”). Zastąp opcję „zwolnionych kamieni milowych” dotyczącą tylko problemów. kamienie milowe zwolnienia: # opcjonalne, domyślnie # Kamienie milowe, które oznaczają, że żądanie ściągnięcia nie jest oznaczane jako nieaktualne. Poszczególne kamienie milowe oddziel przecinkami (np. „kamień milowy 1, kamień milowy 2”). Zastąp opcję „zwolnionych kamieni milowych” dotyczącą tylko żądań ściągnięcia. zwolnienia-pr-milestones: # opcjonalne, domyślnie # Zwolnij wszystkie problemy i żądania ściągnięcia z kamieniami milowymi, aby nie były oznaczane jako nieaktualne. Domyślnie fałszywe. zwolnione-wszystkie-milestones: # opcjonalne, wartość domyślna to false # Zwolnij wszystkie problemy z kamieniami milowymi od oznaczania ich jako nieaktualne. Zastąp opcję „wyłącz wszystkie kamienie milowe” dotyczącą tylko problemów. kamienie milowe zwolnienia: # opcjonalne, domyślnie # Zwolnij wszystkie żądania ściągnięcia z kamieniami milowymi od oznaczania ich jako nieaktualne. Zastąp opcję „wyłącz wszystkie kamienie milowe” dotyczącą tylko żądań ściągnięcia. zwolnienia-all-pr-milestones: # opcjonalne, domyślnie # Jeśli są nieaktualne, sprawdzane są tylko problemy lub żądania ściągnięcia ze wszystkimi tymi etykietami. Domyślnie jest to `` (wyłączone) i może być listą etykiet oddzielonych przecinkami. only-labels: # opcjonalne, domyślnie # Jeśli są nieaktualne, sprawdzane są tylko problemy lub żądania ściągnięcia z co najmniej jedną z tych etykiet. Domyślnie jest to `` (wyłączone) i może być listą etykiet oddzielonych przecinkami. any-of-labels: # opcjonalne, domyślnie # Jeśli są nieaktualne, sprawdzane są tylko problemy z co najmniej jedną z tych etykiet. Domyślnie jest to `` (wyłączone) i może być listą etykiet oddzielonych przecinkami. Zastąp opcję „dowolna z etykiet” dotyczącą tylko problemów. any-of-issue-labels: # opcjonalne, domyślnie # Jeśli są nieaktualne, sprawdzane są tylko żądania ściągnięcia z co najmniej jedną z tych etykiet. Domyślnie jest to `` (wyłączone) i może być listą etykiet oddzielonych przecinkami. Zastąp opcję „dowolna z etykiet” dotyczącą tylko żądań ściągnięcia. any-of-pr-labels: # opcjonalne, domyślnie # Jeśli są nieaktualne, sprawdzane są tylko problemy ze wszystkimi tymi etykietami. Domyślnie jest to `[]` (wyłączone) i może to być lista etykiet oddzielonych przecinkami. Zastąp opcję „tylko etykiety” dotyczącą tylko problemów. only-issue-labels: # opcjonalne, domyślnie # Jeśli są nieaktualne, sprawdzane są tylko żądania ściągnięcia ze wszystkimi tymi etykietami. Domyślnie jest to `[]` (wyłączone) i może to być lista etykiet oddzielonych przecinkami. Zastąp opcję „only-labels” dotyczącą tylko żądań ściągnięcia. only-pr-labels: # opcjonalne, domyślnie # Maksymalna liczba operacji na uruchomienie, używana do kontrolowania ograniczenia szybkości (związane z GitHub API CRUD). liczba operacji na przebieg: # opcjonalna, wartość domyślna to 30 # Usuń nieaktualne etykiety ze problemów i żądania ściągnięcia, gdy zostaną zaktualizowane lub skomentowane. usuń-stale-when-updated: # opcjonalne, wartość domyślna to true # Usuń nieaktualne etykiety z problemów, gdy są aktualizowane lub komentowane. Zastąp opcję „usuń nieaktualne-po aktualizacji” dotyczącą tylko problemów. usuń-problem-nieaktualny-po aktualizacji: # opcjonalne, domyślnie # Usuń nieaktualne etykiety z żądań ściągnięcia, gdy są aktualizowane lub komentowane. Zastąp opcję „usuń nieaktualne-po aktualizacji” dotyczącą tylko żądań ściągnięcia. usuń-pr-stale-when-updated: # opcjonalne, domyślnie # Uruchom procesor w trybie debugowania, nie wykonując w rzeczywistości żadnych operacji na bieżących problemach. debug-only: # opcjonalne, wartość domyślna to false # Kolejność rozwiązywania problemów lub żądań ściągnięcia. Domyślnie ustawiona jest wartość false, która jest malejąca. rosnąco: # opcjonalne, domyślnie jest to fałsz # Usuń gałąź git po zamknięciu nieaktualnego żądania ściągnięcia. usuń-branch: # opcjonalne, wartość domyślna to false # Data używana do pominięcia nieaktualnej akcji w przypadku problemu/żądania ściągnięcia utworzonego przed nią (ISO 8601 lub RFC 2822). data-początkowa: # opcjonalna, domyślnie # Osoby, które zwalniają problem lub żądanie ściągnięcia z oznaczenia jako nieaktualne. Oddziel wielu przypisanych przecinkami (np. „użytkownik1,użytkownik2”). zwolnienie-cesjonariuszy: # opcjonalne, domyślnie # Osoby, które zwalniają problem z oznaczenia go jako nieaktualny. Oddziel wielu przypisanych przecinkami (np. „użytkownik1,użytkownik2”). Zastąp opcję „osoby zwolnione” dotyczącą tylko problemów. zwolnienie-wydania-przypisani: # opcjonalne, domyślnie # Osoby, które zwalniają żądanie ściągnięcia z oznaczenia jako nieaktualne. Oddziel wielu przypisanych przecinkami (np. „użytkownik1,użytkownik2”). Zastąp opcję „osoby zwolnione” dotyczącą tylko żądań ściągnięcia. zwolnienie-pr-cesjonariuszy: # opcjonalne, domyślnie # Zwolnij wszystkie problemy i żądania ściągnięcia od cesjonariuszy, aby nie były oznaczane jako nieaktualne. Domyślnie fałszywe. zwolnieni-wszyscy-przypisani: # opcjonalne, wartość domyślna to fałsz # Zwolnij wszystkie problemy z cesjonariuszami z oznaczania ich jako nieaktualne. Zastąp opcję „zwolnij wszystkich cesjonariuszy” dotyczącą tylko problemów. cesjonariusze zwolnieni ze wszystkich problemów: # opcjonalne, domyślnie # Zwolnij wszystkie żądania ściągnięcia od cesjonariuszy z oznaczania ich jako nieaktualne. Zastąp opcję „zwolnij wszystkich cesjonariuszy” dotyczącą tylko żądań ściągnięcia. zwolnienie-wszystkich-przypisanych: # opcjonalne, domyślnie # Zwolnij żądania ściągnięcia wersji roboczej z oznaczania ich jako nieaktualne. Domyślnie fałszywe. zwolnienie-draft-pr: # opcjonalne, wartość domyślna to fałsz # Wyświetl na końcu statystyki dotyczące nieaktualnego przepływu pracy (tylko wtedy, gdy włączone są dzienniki). Enable-statistics: # opcjonalne, wartość domyślna to true # Rozdzielana przecinkami lista etykiet do dodania, gdy nieaktualny problem lub żądanie ściągnięcia odbierze aktywność i zostanie z niej usunięta etykieta nieaktualnego wydania lub etykieta nieaktualnego pr. etykiety-do-dodania-kiedy-odnowione: # opcjonalne, domyślnie # Rozdzielana przecinkami lista etykiet do usunięcia, gdy nieaktualny problem lub żądanie ściągnięcia odbierze aktywność i usunie się z niej etykietę nieaktualnego wydania lub etykietę nieaktualnego pr. etykiety-do-usunięcia-gdy-odświeżone: # opcjonalne, domyślnie # Każda aktualizacja (aktualizacja/komentarz) może zresetować nieaktualny czas bezczynności w przypadku problemów i żądań ściągnięcia. ignorowanie aktualizacji: # opcjonalne, wartość domyślna to fałsz # Każda aktualizacja (aktualizacja/komentarz) może zresetować nieaktualny czas bezczynności dotyczący problemów. Zastąp opcję „ignoruj ​​aktualizacje” dotyczącą tylko problemów. ignorowanie-problem-aktualizacje: # opcjonalne, domyślnie # Każda aktualizacja (aktualizacja/komentarz) może zresetować nieaktualny czas bezczynności żądań ściągnięcia. Zastąp opcję „ignorowania aktualizacji” dotyczącą tylko żądań ściągnięcia. ignorowanie-pr-updates: # opcjonalne, domyślnie

<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Fixes # (issue)

## Checklist

- [ ] I have run `make tidy` to update any new dependencies
- [ ] I have run `make lint` to verify my code passes the lint check
  - [ ] I have formatted my code using `gofumpt`

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [ ] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
